### PR TITLE
Use flex server database resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@ The following resources are used by this module:
 
 - [azurerm_management_lock.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/management_lock) (resource)
 - [azurerm_monitor_diagnostic_setting.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_diagnostic_setting) (resource)
-- [azurerm_postgresql_database.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/postgresql_database) (resource)
 - [azurerm_postgresql_flexible_server.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/postgresql_flexible_server) (resource)
+- [azurerm_postgresql_flexible_server_database.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/postgresql_flexible_server_database) (resource)
 - [azurerm_private_endpoint.this_managed_dns_zone_groups](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_endpoint) (resource)
 - [azurerm_private_endpoint.this_unmanaged_dns_zone_groups](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_endpoint) (resource)
 - [azurerm_private_endpoint_application_security_group_association.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_endpoint_application_security_group_association) (resource)
@@ -154,8 +154,6 @@ Default: `null`
 Description: - `charset` - (Required)  Specifies the Charset for the PostgreSQL Database, which needs [to be a valid PostgreSQL Charset](https://www.postgresql.org/docs/current/static/multibyte.html). Changing this forces a new resource to be created.
 - `collation` - (Required) Specifies the Collation for the PostgreSQL Database, which needs [to be a valid PostgreSQL Collation](https://www.postgresql.org/docs/current/static/collation.html). Note that Microsoft uses different [notation](https://msdn.microsoft.com/library/windows/desktop/dd373814.aspx)
 - `name` - (Required) Specifies the name of the PostgreSQL Database, which needs [to be a valid PostgreSQL identifier](https://www.postgresql.org/docs/current/static/sql-syntax-lexical.html#SQL-SYNTAX-IDENTIFIERS). Changing this forces a new resource to be created.
-- `resource_group_name` - (Required) The name of the resource group in which the PostgreSQL Server exists. Changing this forces a new resource to be created.
-- `server_name` - (Required) Specifies the name of the PostgreSQL Server. Changing this forces a new resource to be created.
 
 ---
 `timeouts` block supports the following:
@@ -167,11 +165,9 @@ Type:
 
 ```hcl
 map(object({
-    charset             = string
-    collation           = string
-    name                = string
-    resource_group_name = string
-    server_name         = string
+    charset   = string
+    collation = string
+    name      = string
     timeouts = optional(object({
       create = optional(string)
       delete = optional(string)

--- a/main.databases.tf
+++ b/main.databases.tf
@@ -1,11 +1,10 @@
-resource "azurerm_postgresql_database" "this" {
+resource "azurerm_postgresql_flexible_server_database" "this" {
   for_each = var.databases
 
-  charset             = each.value.charset
-  collation           = each.value.collation
-  name                = each.value.name
-  resource_group_name = each.value.resource_group_name
-  server_name         = each.value.server_name
+  name      = each.value.name
+  server_id = azurerm_postgresql_flexible_server.this.id
+  charset   = each.value.charset
+  collation = each.value.collation
 
   dynamic "timeouts" {
     for_each = each.value.timeouts == null ? [] : [each.value.timeouts]
@@ -14,6 +13,7 @@ resource "azurerm_postgresql_database" "this" {
       create = timeouts.value.create
       delete = timeouts.value.delete
       read   = timeouts.value.read
+      update = timeouts.value.update
     }
   }
 }

--- a/main.databases.tf
+++ b/main.databases.tf
@@ -13,7 +13,6 @@ resource "azurerm_postgresql_flexible_server_database" "this" {
       create = timeouts.value.create
       delete = timeouts.value.delete
       read   = timeouts.value.read
-      update = timeouts.value.update
     }
   }
 }

--- a/variables.databases.tf
+++ b/variables.databases.tf
@@ -3,7 +3,6 @@ variable "databases" {
     charset   = string
     collation = string
     name      = string
-    server_id = string
     timeouts = optional(object({
       create = optional(string)
       delete = optional(string)
@@ -15,7 +14,6 @@ variable "databases" {
  - `charset` - (Required)  Specifies the Charset for the PostgreSQL Database, which needs [to be a valid PostgreSQL Charset](https://www.postgresql.org/docs/current/static/multibyte.html). Changing this forces a new resource to be created.
  - `collation` - (Required) Specifies the Collation for the PostgreSQL Database, which needs [to be a valid PostgreSQL Collation](https://www.postgresql.org/docs/current/static/collation.html). Note that Microsoft uses different [notation](https://msdn.microsoft.com/library/windows/desktop/dd373814.aspx)
  - `name` - (Required) Specifies the name of the PostgreSQL Database, which needs [to be a valid PostgreSQL identifier](https://www.postgresql.org/docs/current/static/sql-syntax-lexical.html#SQL-SYNTAX-IDENTIFIERS). Changing this forces a new resource to be created.
- - `server_id` - (Required) Specifies the resource ID of the PostgreSQL Server. Changing this forces a new resource to be created.
 
  ---
  `timeouts` block supports the following:

--- a/variables.databases.tf
+++ b/variables.databases.tf
@@ -8,7 +8,6 @@ variable "databases" {
       create = optional(string)
       delete = optional(string)
       read   = optional(string)
-      update = optional(string)
     }))
   }))
   default     = {}

--- a/variables.databases.tf
+++ b/variables.databases.tf
@@ -1,14 +1,14 @@
 variable "databases" {
   type = map(object({
-    charset             = string
-    collation           = string
-    name                = string
-    resource_group_name = string
-    server_name         = string
+    charset   = string
+    collation = string
+    name      = string
+    server_id = string
     timeouts = optional(object({
       create = optional(string)
       delete = optional(string)
       read   = optional(string)
+      update = optional(string)
     }))
   }))
   default     = {}
@@ -16,8 +16,7 @@ variable "databases" {
  - `charset` - (Required)  Specifies the Charset for the PostgreSQL Database, which needs [to be a valid PostgreSQL Charset](https://www.postgresql.org/docs/current/static/multibyte.html). Changing this forces a new resource to be created.
  - `collation` - (Required) Specifies the Collation for the PostgreSQL Database, which needs [to be a valid PostgreSQL Collation](https://www.postgresql.org/docs/current/static/collation.html). Note that Microsoft uses different [notation](https://msdn.microsoft.com/library/windows/desktop/dd373814.aspx)
  - `name` - (Required) Specifies the name of the PostgreSQL Database, which needs [to be a valid PostgreSQL identifier](https://www.postgresql.org/docs/current/static/sql-syntax-lexical.html#SQL-SYNTAX-IDENTIFIERS). Changing this forces a new resource to be created.
- - `resource_group_name` - (Required) The name of the resource group in which the PostgreSQL Server exists. Changing this forces a new resource to be created.
- - `server_name` - (Required) Specifies the name of the PostgreSQL Server. Changing this forces a new resource to be created.
+ - `server_id` - (Required) Specifies the resource ID of the PostgreSQL Server. Changing this forces a new resource to be created.
 
  ---
  `timeouts` block supports the following:


### PR DESCRIPTION
## Description

Current Database resource is for Postgres Single Server. Fixing it by using database resource for Postgres Flex Server.
<!--
>Thank you for your contribution !
> Please include a summary of the change and which issue is fixed.
> Please also include the context.
> List any dependencies that are required for this change.

-->

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [x] Azure Verified Module updates:
  - [x] Bugfix containing backwards compatible bug fixes
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [x] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [x] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [ ] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
